### PR TITLE
Update blockwallet.mdx: reminder to double confirm ETH address

### DIFF
--- a/src/docs/guides/blockwallet.mdx
+++ b/src/docs/guides/blockwallet.mdx
@@ -44,7 +44,7 @@ To cater to users of all levels, BlockWallet presents a user-friendly interface,
 10. Scan the QR code with your PC's camera.
     ![](/img/blockwallet/11.png)
 
-11. To continue, select the account that you want to import and hit “Import”. Voila, you have successfully imported your AirGap account into BlockWallet.
+11. To continue, select the account that you want to import and hit “Import”. Voila, you have successfully imported your AirGap account into BlockWallet. (**Make sure the address shown on BlockWallet is correct!**)  
     Now, open the extension. You'll be able to see your account balance.
     ![](/img/blockwallet/12.png)
 


### PR DESCRIPTION
In my experiments, because of unknown reason, **sometimes** BlockWallet on PC will show incorrect address. 

If that's the case, receiving crypto to that address would cause fund loss. I added a reminder to double confirm address while importing.