### PR TITLE
docs: replace dead gas oracle links (ethgasstation, gasnow) with working alternatives

### DIFF
--- a/src/docs/troubleshooting/currencies/ethereum/transaction-stuck.mdx
+++ b/src/docs/troubleshooting/currencies/ethereum/transaction-stuck.mdx
@@ -7,7 +7,7 @@ If your Ethereum transaction is stuck, it is most likely due to low fees.
 On the Ethereum network, transactions are prioritised by the amount of fees they pay to the miners. If you set a low fee, the miners are less likely to include the transaction in a block.
 
 :::tip Gas Prices
-You can use **[GAS NOW](https://www.gasnow.org/)** or **[ETH GAS STATION](https://www.ethgasstation.info/)** to see the current average fees on the network.
+You can use the **[Etherscan Gas Tracker](https://etherscan.io/gastracker)** or **[Blocknative Gas Estimator](https://www.blocknative.com/gas-estimator)** to see the current average fees on the network. Both `gasnow.org` and `ethgasstation.info` are no longer active. For a comparison of gas oracle accuracy across providers, see the [OpenChainBench gas estimation benchmark](https://openchainbench.com/benchmarks/gas-estimation).
 :::
 
 When this happens, you have the following options.


### PR DESCRIPTION
## Summary

Both `ethgasstation.info` and `gasnow.org` are no longer active as gas oracles:

- `ethgasstation.info` returns HTTP 403 (service shut down by ConsenSys in 2022)
- `gasnow.org` has been repurposed as an unrelated crypto casino site

The Ethereum "transaction stuck" troubleshooting page currently points readers to both, which is confusing for AirGap users trying to unstick a transaction.

## Fix

Replaces the two dead links with currently working alternatives (Etherscan Gas Tracker and Blocknative Gas Estimator), and adds a reference to the OpenChainBench gas estimation benchmark for a live comparison of gas oracle accuracy across providers.

## Test plan

- [x] Verified both dead URLs return errors or unrelated content
- [x] New URLs return 200 with the expected content
- [x] Preserves the existing bold link style within the tip block